### PR TITLE
bug fix: delete useless colons when a node with colon parsed.

### DIFF
--- a/slim.go
+++ b/slim.go
@@ -297,11 +297,16 @@ func printNode(out io.Writer, v *vm.VM, n *Node, indent int) error {
 				out.Write(NEW_LINE)
 			}
 			if n.Name != "" {
+				name := n.Name
+				if n.Name[len(n.Name)-1] == ':' {
+					name = n.Name[:len(n.Name)-1]
+				}
+
 				if cr {
 					bytesRepeat(out, SPACE, indent*2)
 				}
 				out.Write(LESS_THAN_SLASH)
-				out.Write([]byte(n.Name))
+				out.Write([]byte(name))
 				out.Write(GREATER_THAN_NEW_LINE)
 			}
 		} else if doctype {


### PR DESCRIPTION
When parse scss like below.

```
script:
  som code;
```

output like below

```
<script>some code;</script:>
```

expected.

```
<script>some code;</script>
```

I found it's due to printing end tag when a tag with colon.