### PR TITLE
bugfix failed write attribute

### DIFF
--- a/slim.go
+++ b/slim.go
@@ -552,7 +552,7 @@ func Parse(in io.Reader) (*Template, error) {
 				}
 			case sAttrValue:
 				if eol {
-					if unicode.IsLetter(r) || r == '"' {
+					if unicode.IsLetter(r) || unicode.IsNumber(r) || r == '"' {
 						avalue += string(r)
 						if avalue[0] == '"' && avalue[len(avalue)-1] == '"' {
 							avalue = avalue[1 : len(avalue)-1]

--- a/slim_test.go
+++ b/slim_test.go
@@ -350,3 +350,20 @@ func TestNoRaw(t *testing.T) {
 		t.Fatalf("expected %v but %v", expect, got)
 	}
 }
+
+func TestAttr(t *testing.T) {
+    tmpl, err := ParseFile("testdir/test_attr.slim")
+    if err != nil {
+        t.Fatal(err)
+    }
+    var buf bytes.Buffer
+    err = tmpl.Execute(&buf, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+    expect := readFile("testdir/test_attr.html")
+    got := buf.String()
+    if expect != got {
+		t.Fatalf("expected %v but %v", expect, got)
+    }
+}

--- a/slim_test.go
+++ b/slim_test.go
@@ -352,18 +352,18 @@ func TestNoRaw(t *testing.T) {
 }
 
 func TestAttr(t *testing.T) {
-    tmpl, err := ParseFile("testdir/test_attr.slim")
-    if err != nil {
-        t.Fatal(err)
-    }
-    var buf bytes.Buffer
-    err = tmpl.Execute(&buf, nil)
+	tmpl, err := ParseFile("testdir/test_attr.slim")
 	if err != nil {
 		t.Fatal(err)
 	}
-    expect := readFile("testdir/test_attr.html")
-    got := buf.String()
-    if expect != got {
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := readFile("testdir/test_attr.html")
+	got := buf.String()
+	if expect != got {
 		t.Fatalf("expected %v but %v", expect, got)
-    }
+	}
 }

--- a/testdir/test_attr.html
+++ b/testdir/test_attr.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8"/>
+    <title>your name.</title>
+  </head>
+  <body>
+    <div class="p-3">
+      <form>
+        <label for="your-name" class="form-label">Your Name</label>
+        <input id="your-name" class="form-control" name="your-name"/>
+        <input type="hidden" name="secret" value="1"/>
+      </form>
+    </div>
+  </body>
+</html>

--- a/testdir/test_attr.slim
+++ b/testdir/test_attr.slim
@@ -1,0 +1,11 @@
+doctype 5
+html lang="ja"
+  head
+    meta charset="UTF-8"
+    title your name.
+  body
+    div class=p-3
+      form
+        label for=your-name class=form-label Your Name
+        input id=your-name class=form-control name=your-name
+        input type=hidden name=secret value=1


### PR DESCRIPTION
Hi.
I fixed that failed to write the last attribute when the attribute's value is Num.

## e.g.
```slim
input type=hidden name=secret value=1
div class=p-3
```
```diff
- <input type="hidden" name="secret"/>
- <div>foo</div>
+ <input type="hidden" name="secret" value="1"/>
+ <div class="p-3">foo</div>
```