### PR TITLE
bugfix attr-value judgment

### DIFF
--- a/slim_test.go
+++ b/slim_test.go
@@ -482,3 +482,42 @@ func TestAttr(t *testing.T) {
 		t.Fatalf("expected %v but %v", expect, got)
 	}
 }
+
+func TestIDAndClass(t *testing.T) {
+	tmpl, err := ParseFile("testdir/test_id_and_class.slim")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := readFile(t, "testdir/test_id_and_class.html")
+	got := buf.String()
+	if expect != got {
+		t.Fatalf("expected %v but %v", expect, got)
+	}
+}
+
+func TestIsAttributeValue(t *testing.T) {
+	tests := []struct {
+		in     rune
+		expect bool
+	}{
+		{'å', true},
+		{'A', true},
+		{'"', false},
+		{'\'', false},
+		{'=', false},
+		{'<', false},
+		{'>', false},
+		{'`', false},
+	}
+	for _, tt := range tests {
+		got := isUnquotedAttributeValue(tt.in)
+		if tt.expect != got {
+			t.Fatalf("expected %v but %v when in %s", tt.expect, got, string(tt.in))
+		}
+	}
+}

--- a/testdir/test_id_and_class.html
+++ b/testdir/test_id_and_class.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8"/>
+    <title>your name.</title>
+  </head>
+  <body>
+    <div class="p-3 m-3">
+      <form id="form-box" class="form">
+        <label>Your Name</label>
+        <input type="text" name="your-name"/>
+        <input type="hidden" name="secret" value="1"/>
+      </form>
+    </div>
+  </body>
+</html>

--- a/testdir/test_id_and_class.slim
+++ b/testdir/test_id_and_class.slim
@@ -1,0 +1,11 @@
+doctype 5
+html lang="ja"
+  head
+    meta charset="UTF-8"
+    title your name.
+  body
+    div.p-3.m-3
+      form#form-box.form
+        label Your Name
+        input type=text name=your-name
+        input type=hidden name=secret value=1


### PR DESCRIPTION
I fixed the conditional expression of the attr-value.
But, in this PR isn't all patterns are met.

https://html.spec.whatwg.org/multipage/syntax.html#elements-2
```slim
div.p-3
```
```diff
- <div class="p">3</div>
+ <div class="p-3">
+ </div>
```

### benchmark
<details>
<summary>Old benchmarks</summary>

before::
```
BenchmarkTemplate_Execute-8   	  564622	      2096 ns/op
BenchmarkTemplate_Execute-8   	  565784	      2131 ns/op
BenchmarkTemplate_Execute-8   	  569425	      2124 ns/op
```
after::
```
BenchmarkTemplate_Execute-8   	  564313	      2117 ns/op
BenchmarkTemplate_Execute-8   	  563655	      2116 ns/op
BenchmarkTemplate_Execute-8   	  570637	      2118 ns/op
```

</details>

after merged benchmarks...
before::
```
BenchmarkTemplate_Execute-8   	  616350	      1914 ns/op
BenchmarkTemplate_Execute-8   	  615756	      1940 ns/op
BenchmarkTemplate_Execute-8   	  619611	      1922 ns/op
```
after::
```
BenchmarkTemplate_Execute-8   	  615942	      1937 ns/op
BenchmarkTemplate_Execute-8   	  616814	      1944 ns/op
BenchmarkTemplate_Execute-8   	  621721	      1913 ns/op
```
