### PR TITLE
bugfix syntax error

### DIFF
--- a/slim.go
+++ b/slim.go
@@ -768,10 +768,11 @@ func cssRenderer(out io.Writer, n *Node, v *vm.VM) error {
 }
 
 // ..in addition to the requirements given above for attribute values, must not
-//   contain any literal ASCII whitespace, any U+0022 QUOTATION MARK characters ("),
-//   U+0027 APOSTROPHE characters ('), U+003D EQUALS SIGN characters (=),
-//   U+003C LESS-THAN SIGN characters (<), U+003E GREATER-THAN SIGN characters (>),
-//   or U+0060 GRAVE ACCENT characters (`), and must not be the empty string.
+//
+//	contain any literal ASCII whitespace, any U+0022 QUOTATION MARK characters ("),
+//	U+0027 APOSTROPHE characters ('), U+003D EQUALS SIGN characters (=),
+//	U+003C LESS-THAN SIGN characters (<), U+003E GREATER-THAN SIGN characters (>),
+//	or U+0060 GRAVE ACCENT characters (`), and must not be the empty string.
 func isUnquotedAttributeValue(r rune) bool {
 	return !(unicode.IsSpace(r) ||
 		r == '"' || r == '\'' || r == '=' ||

--- a/slim.go
+++ b/slim.go
@@ -533,7 +533,11 @@ func Parse(in io.Reader) (*Template, error) {
 				default:
 					if !isUnquotedAttributeValue(r) { // FIXME
 						node.ID = id
-						st = sEq
+						if unicode.IsSpace(r) {
+							st = sAttrKey
+						} else {
+							st = sEq
+						}
 					} else {
 						id += string(r)
 					}
@@ -557,7 +561,11 @@ func Parse(in io.Reader) (*Template, error) {
 						if class != "" {
 							node.Class = append(node.Class, class)
 						}
-						st = sEq
+						if unicode.IsSpace(r) {
+							st = sAttrKey
+						} else {
+							st = sEq
+						}
 					} else {
 						class += string(r)
 					}

--- a/slim_test.go
+++ b/slim_test.go
@@ -504,7 +504,8 @@ func TestIDClassAndAttr(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	err = tmpl.Execute(&buf, Values{
-		"secret": 1,
+		"title": "HELLO, RENDER",
+		"text":  "Hello, Render",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/slim_test.go
+++ b/slim_test.go
@@ -497,6 +497,25 @@ func TestIDAndClass(t *testing.T) {
 	}
 }
 
+func TestIDClassAndAttr(t *testing.T) {
+	tmpl, err := ParseFile("testdir/test_id_class_and_attrs.slim")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, Values{
+		"secret": 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := readFile(t, "testdir/test_id_class_and_attrs.html")
+	got := buf.String()
+	if expect != got {
+		t.Fatalf("expected %v but %v", expect, got)
+	}
+}
+
 func TestIsAttributeValue(t *testing.T) {
 	tests := []struct {
 		in     rune

--- a/slim_test.go
+++ b/slim_test.go
@@ -498,7 +498,7 @@ func TestIDAndClass(t *testing.T) {
 }
 
 func TestIDClassAndAttr(t *testing.T) {
-	tmpl, err := ParseFile("testdir/test_id_class_and_attrs.slim")
+	tmpl, err := ParseFile("testdata/test_id_class_and_attrs.slim")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -510,7 +510,7 @@ func TestIDClassAndAttr(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expect := readFile(t, "testdir/test_id_class_and_attrs.html")
+	expect := readFile(t, "testdata/test_id_class_and_attrs.html")
 	got := buf.String()
 	if expect != got {
 		t.Fatalf("expected %v but %v", expect, got)

--- a/testdata/test_attr.slim
+++ b/testdata/test_attr.slim
@@ -4,8 +4,8 @@ html lang="ja"
     meta charset="UTF-8"
     title your name.
   body
-    div class=p-3
+    div class="p-3"
       form
-        label for=your-name class=form-label Your Name
-        input id=your-name class=form-control name=your-name
-        input type=hidden name=secret value=1
+        label for="your-name" class="form-label" Your Name
+        input id="your-name" class="form-control" name="your-name"
+        input type="hidden" name="secret" value=1

--- a/testdata/test_id_and_class.slim
+++ b/testdata/test_id_and_class.slim
@@ -7,5 +7,5 @@ html lang="ja"
     div.p-3.m-3
       form#form-box.form
         label Your Name
-        input type=text name=your-name
-        input type=hidden name=secret value=1
+        input type="text" name="your-name"
+        input type="hidden" name="secret" value=1

--- a/testdata/test_id_class_and_attrs.html
+++ b/testdata/test_id_class_and_attrs.html
@@ -5,6 +5,8 @@
     <title>your name.</title>
   </head>
   <body>
+    <h1 id="title">HELLO, RENDER</h1>
+    <p class="p-3">Hello, Render</p>
     <div class="p-3">
       <form id="form-box" method="post">
         <label class="form-label" for="your-name">Your Name</label>

--- a/testdata/test_id_class_and_attrs.html
+++ b/testdata/test_id_class_and_attrs.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8"/>
+    <title>your name.</title>
+  </head>
+  <body>
+    <div class="p-3">
+      <form id="form-box" method="post">
+        <label class="form-label" for="your-name">Your Name</label>
+        <input id="your-name" class="form-control" name="your-name"/>
+        <input type="hidden" name="secret" value="1"/>
+      </form>
+    </div>
+  </body>
+</html>

--- a/testdata/test_id_class_and_attrs.slim
+++ b/testdata/test_id_class_and_attrs.slim
@@ -1,0 +1,11 @@
+doctype 5
+html lang=ja
+  head
+    meta charset="UTF-8"
+    title your name.
+  body
+    div.p-3
+      form#form-box method="post"
+        label.form-label for="your-name" Your Name
+        input#your-name.form-control name="your-name"
+        input type="hidden" name="secret" value=1

--- a/testdata/test_id_class_and_attrs.slim
+++ b/testdata/test_id_class_and_attrs.slim
@@ -4,6 +4,8 @@ html lang=ja
     meta charset="UTF-8"
     title your name.
   body
+    h1#title=title
+    p.p-3=text
     div.p-3
       form#form-box method="post"
         label.form-label for="your-name" Your Name


### PR DESCRIPTION
I fixed syntax errors for attr or text when used id or class, and fixed mistake test case.
```slim
form#form-box method="post"

label.form-label for="your-name" Your Name
```
```diff
- syntax error: method="post"
+ <form id="form-box" method="post">
+ </form>

- syntax error: for="your-name" Your Name
+ <label class="form-label" for="your-name">Your Name</label>
```