### PR TITLE
Add license, update godoc link

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+The MIT License (MIT)
 
 Copyright (c) 2022 Yasuhiro Matsumoto
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/mattn/go-slim/workflows/test/badge.svg?branch=master)](https://github.com/mattn/go-slim/actions?query=workflow%3Atest)
 [![Codecov](https://codecov.io/gh/mattn/go-slim/branch/master/graph/badge.svg)](https://codecov.io/gh/mattn/go-slim)
-[![GoDoc](https://godoc.org/github.com/mattn/go-slim?status.svg)](http://godoc.org/github.com/mattn/go-slim)
+[![Go Reference](https://pkg.go.dev/badge/github.com/mattn/go-slim.svg)](https://pkg.go.dev/github.com/mattn/go-slim)
 [![Go Report Card](https://goreportcard.com/badge/github.com/mattn/go-slim)](https://goreportcard.com/report/github.com/mattn/go-slim)
 
 slim template engine for golang


### PR DESCRIPTION
Godoc.org now redirects to pkg.go.dev. The new GoDoc tool displays limited information for repos that lack a license. Based on the MIT license indication in the README.md, I have constructed this license and updated the README to bypass the redirect.